### PR TITLE
modify to not use "BinaryFormatter"

### DIFF
--- a/UI/Connect4/v1/Connect4UI.resx
+++ b/UI/Connect4/v1/Connect4UI.resx
@@ -117,17 +117,4 @@
   <resheader name="writer">
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
-  <data name="board1.ColorMap" mimetype="application/x-microsoft.net.object.binary.base64">
-    <value>
-        AAEAAAD/////AQAAAAAAAAAMAgAAAFFTeXN0ZW0uRHJhd2luZywgVmVyc2lvbj00LjAuMC4wLCBDdWx0
-        dXJlPW5ldXRyYWwsIFB1YmxpY0tleVRva2VuPWIwM2Y1ZjdmMTFkNTBhM2EEAQAAAIwBU3lzdGVtLkNv
-        bGxlY3Rpb25zLkdlbmVyaWMuTGlzdGAxW1tTeXN0ZW0uRHJhd2luZy5Db2xvciwgU3lzdGVtLkRyYXdp
-        bmcsIFZlcnNpb249NC4wLjAuMCwgQ3VsdHVyZT1uZXV0cmFsLCBQdWJsaWNLZXlUb2tlbj1iMDNmNWY3
-        ZjExZDUwYTNhXV0DAAAABl9pdGVtcwVfc2l6ZQhfdmVyc2lvbgQAABZTeXN0ZW0uRHJhd2luZy5Db2xv
-        cltdAgAAAAgICQMAAAABAAAABgAAAAcDAAAAAAEAAAAEAAAABBRTeXN0ZW0uRHJhd2luZy5Db2xvcgIA
-        AAAF/P///xRTeXN0ZW0uRHJhd2luZy5Db2xvcgQAAAAEbmFtZQV2YWx1ZQprbm93bkNvbG9yBXN0YXRl
-        AQAAAAkHBwIAAAAKAAAAAAAAAACkAAEAAfv////8////CgAAAAAAAAAAAAAAAAH6/////P///woAAAAA
-        AAAAAAAAAAAB+f////z///8KAAAAAAAAAAAAAAAACw==
-</value>
-  </data>
 </root>

--- a/UI/Connect4/v2/Board.cs
+++ b/UI/Connect4/v2/Board.cs
@@ -7,7 +7,6 @@ namespace UI.Connect4.v2
 	{
 		private Dictionary<(int, int), (int, ImageAttributes, Color?)> Attributes { get; set; } = new();
 		private ImageAttributes DefaultAttributes { get; set; }
-		public List<Color> ColorMap { get; set; }
 		public int TokenSize { get; private set; } = 100;
 		public int RowCount { get; private set; }
 		public int ColumnCount { get; private set; }
@@ -15,14 +14,14 @@ namespace UI.Connect4.v2
 		private readonly Image TokenImage = new Bitmap(Resources.Connect4_Token);
 		private static ImageAttributes BuildAttributes(Color color)
 		{
-			ColorMatrix matrix = new(new float[5][]
-			{
-				new float[5] { color.R / 255f, 0, 0, 0, 0},
-				new float[5] { 0, color.G / 255f, 0, 0, 0},
-				new float[5] { 0, 0, color.B / 255f, 0, 0},
-				new float[5] { 0, 0, 0, color.A / 255f, 0},
-				new float[5] { 0, 0, 0, 0, 1}
-			});
+			ColorMatrix matrix = new(
+			[
+				[color.R / 255f, 0, 0, 0, 0],
+				[0, color.G / 255f, 0, 0, 0],
+				[0, 0, color.B / 255f, 0, 0],
+				[0, 0, 0, color.A / 255f, 0],
+				[0, 0, 0, 0, 1]
+			]);
 			ImageAttributes toReturn = new();
 			toReturn.SetColorMatrix(matrix);
 			return toReturn;
@@ -33,7 +32,6 @@ namespace UI.Connect4.v2
 			InitializeComponent();
 			SetTokenSize(TokenSize);
 			DefaultAttributes = BuildAttributes(Color.White);
-			ColorMap = new() { Color.White };
 			pictureBox1.Paint += Board_Paint;
 			pictureBox1.MouseUp += Picture_Click;
 			pictureBox1.BackColor = Color.Yellow;
@@ -59,10 +57,10 @@ namespace UI.Connect4.v2
 		{
 			RowCount = rows;
 			ColumnCount = columns;
-			Attributes = new();
+			Attributes = [];
 			SetTokenSize(TokenSize);
 		}
-		public void Update(int[,] newState)
+		public void Update(int[,] newState, List<Color> colorMap)
 		{
 			RowCount = newState.GetLength(0);
 			ColumnCount = newState.GetLength(1);
@@ -70,9 +68,10 @@ namespace UI.Connect4.v2
 			{
 				for (int column = 0; column < ColumnCount; column++)
 				{
-					if (!Attributes.TryGetValue((row, column), out var attr) || newState[row, column] != attr.Item1)
+					int tokenState = newState[row, column];
+					if (tokenState != 0 && (!Attributes.TryGetValue((row, column), out var attr) || tokenState != attr.Item1))
 					{
-						Attributes[(row, column)] = (newState[row, column], BuildAttributes(ColorMap[newState[row, column]]), null);
+						Attributes[(row, column)] = (tokenState, BuildAttributes(colorMap[tokenState - 1]), null);
 					}
 				}
 			}
@@ -111,12 +110,12 @@ namespace UI.Connect4.v2
 						}
 					}
 					e.Graphics.DrawImage(
-							TokenImage,
-							rect,
-							0, 0, TokenImage.Width, TokenImage.Height,
-							GraphicsUnit.Pixel,
-							attributes ?? DefaultAttributes
-						);
+						TokenImage,
+						rect,
+						0, 0, TokenImage.Width, TokenImage.Height,
+						GraphicsUnit.Pixel,
+						attributes ?? DefaultAttributes
+					);
 				}
 			}
 		}

--- a/UI/Connect4/v2/Connect4UI.Designer.cs
+++ b/UI/Connect4/v2/Connect4UI.Designer.cs
@@ -1,61 +1,59 @@
 ﻿namespace UI.Connect4.v2
 {
-    partial class Connect4UI
-    {
-        /// <summary>
-        /// Required designer variable.
-        /// </summary>
-        private System.ComponentModel.IContainer components = null;
+	partial class Connect4UI
+	{
+		/// <summary>
+		/// Required designer variable.
+		/// </summary>
+		private System.ComponentModel.IContainer components = null;
 
-        /// <summary>
-        /// Clean up any resources being used.
-        /// </summary>
-        /// <param name="disposing">true if managed resources should be disposed; otherwise, false.</param>
-        protected override void Dispose(bool disposing)
-        {
-            if (disposing && (components != null))
-            {
-                components.Dispose();
-            }
-            base.Dispose(disposing);
-        }
+		/// <summary>
+		/// Clean up any resources being used.
+		/// </summary>
+		/// <param name="disposing">true if managed resources should be disposed; otherwise, false.</param>
+		protected override void Dispose(bool disposing)
+		{
+			if (disposing && (components != null))
+			{
+				components.Dispose();
+			}
+			base.Dispose(disposing);
+		}
 
-        #region Windows Form Designer generated code
+		#region Windows Form Designer generated code
 
-        /// <summary>
-        /// Required method for Designer support - do not modify
-        /// the contents of this method with the code editor.
-        /// </summary>
-        private void InitializeComponent()
-        {
-            System.ComponentModel.ComponentResourceManager resources = new System.ComponentModel.ComponentResourceManager(typeof(Connect4UI));
-            board1 = new Board();
-            SuspendLayout();
-            // 
-            // board1
-            // 
-            board1.ColorMap = (List<Color>)resources.GetObject("board1.ColorMap");
-            board1.Location = new Point(12, 11);
-            board1.Margin = new Padding(3, 2, 3, 2);
-            board1.Name = "board1";
-            board1.Size = new Size(751, 617);
-            board1.TabIndex = 0;
-            // 
-            // Connect4UI
-            // 
-            AutoScaleDimensions = new SizeF(7F, 15F);
-            AutoScaleMode = AutoScaleMode.Font;
-            AutoScroll = true;
-            ClientSize = new Size(786, 639);
-            Controls.Add(board1);
-            Margin = new Padding(3, 2, 3, 2);
-            Name = "Connect4UI";
-            Text = "Connect4UI";
-            ResumeLayout(false);
-        }
+		/// <summary>
+		/// Required method for Designer support - do not modify
+		/// the contents of this method with the code editor.
+		/// </summary>
+		private void InitializeComponent()
+		{
+			board1 = new Board();
+			SuspendLayout();
+			// 
+			// board1
+			// 
+			board1.Location = new Point(12, 11);
+			board1.Margin = new Padding(3, 2, 3, 2);
+			board1.Name = "board1";
+			board1.Size = new Size(700, 600);
+			board1.TabIndex = 0;
+			// 
+			// Connect4UI
+			// 
+			AutoScaleDimensions = new SizeF(7F, 15F);
+			AutoScaleMode = AutoScaleMode.Font;
+			AutoScroll = true;
+			ClientSize = new Size(786, 639);
+			Controls.Add(board1);
+			Margin = new Padding(3, 2, 3, 2);
+			Name = "Connect4UI";
+			Text = "Connect4UI";
+			ResumeLayout(false);
+		}
 
-        #endregion
+		#endregion
 
-        private Board board1;
-    }
+		private Board board1;
+	}
 }

--- a/UI/Connect4/v2/Connect4UI.cs
+++ b/UI/Connect4/v2/Connect4UI.cs
@@ -23,7 +23,6 @@ namespace UI.Connect4.v2
 		{
 			Players.Add(player);
 			Wins[player] = 0;
-			board1.ColorMap.Add(player.Color);
 			board1.ColumnClick += (object? sender, int column) => { player.HandleClick(column); };
 		}
 		public void StartGame(int rows, int columns, bool infinite = false, bool shiftFirstPlayer = false, int betweenGameDelay = 2000)
@@ -37,7 +36,7 @@ namespace UI.Connect4.v2
 					{
 						WinningLength = 4,
 					};
-					game.OnMove += (object? sender, int[,] state) => { board1.Update(state); };
+					game.OnMove += (object? sender, int[,] state) => { board1.Update(state, Players.Select(p => p.Color).ToList()); };
 					game.OnWin += (object? sender, List<(int, int)> win) => { board1.HighlightPieces(win, Color.LawnGreen); };
 					board1.Reset(rows, columns);
 					result = game.Play();
@@ -61,9 +60,6 @@ namespace UI.Connect4.v2
 						var fp = Players.First();
 						Players.Remove(fp);
 						Players.Add(fp);
-						var pc = board1.ColorMap[1];
-						board1.ColorMap.Remove(pc);
-						board1.ColorMap.Add(pc);
 					}
 					Thread.Sleep(betweenGameDelay);
 				} while (infinite);

--- a/UI/Connect4/v2/Connect4UI.resx
+++ b/UI/Connect4/v2/Connect4UI.resx
@@ -117,17 +117,4 @@
   <resheader name="writer">
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
-  <data name="board1.ColorMap" mimetype="application/x-microsoft.net.object.binary.base64">
-    <value>
-        AAEAAAD/////AQAAAAAAAAAMAgAAAFFTeXN0ZW0uRHJhd2luZywgVmVyc2lvbj00LjAuMC4wLCBDdWx0
-        dXJlPW5ldXRyYWwsIFB1YmxpY0tleVRva2VuPWIwM2Y1ZjdmMTFkNTBhM2EEAQAAAIwBU3lzdGVtLkNv
-        bGxlY3Rpb25zLkdlbmVyaWMuTGlzdGAxW1tTeXN0ZW0uRHJhd2luZy5Db2xvciwgU3lzdGVtLkRyYXdp
-        bmcsIFZlcnNpb249NC4wLjAuMCwgQ3VsdHVyZT1uZXV0cmFsLCBQdWJsaWNLZXlUb2tlbj1iMDNmNWY3
-        ZjExZDUwYTNhXV0DAAAABl9pdGVtcwVfc2l6ZQhfdmVyc2lvbgQAABZTeXN0ZW0uRHJhd2luZy5Db2xv
-        cltdAgAAAAgICQMAAAABAAAAAQAAAAcDAAAAAAEAAAAEAAAABBRTeXN0ZW0uRHJhd2luZy5Db2xvcgIA
-        AAAF/P///xRTeXN0ZW0uRHJhd2luZy5Db2xvcgQAAAAEbmFtZQV2YWx1ZQprbm93bkNvbG9yBXN0YXRl
-        AQAAAAkHBwIAAAAKAAAAAAAAAACkAAEAAfv////8////CgAAAAAAAAAAAAAAAAH6/////P///woAAAAA
-        AAAAAAAAAAAB+f////z///8KAAAAAAAAAAAAAAAACw==
-</value>
-  </data>
 </root>


### PR DESCRIPTION
"BinaryFormatter", which was apparently being used to load ColorMap in the Connect4 Board (v2), has been depreciated in .NET 8.0.
Removed ColorMap and switched to using the Player's list to get colors. This avoids having BinaryFormatter used.